### PR TITLE
Ignore .json files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var through = require("through");
+var path    = require("path");
 var to5     = require("6to5");
 var _       = require("lodash");
 
@@ -10,6 +11,10 @@ browserify.configure = function (opts) {
   opts = opts || {};
 
   return function (filename) {
+    if (path.extname(filename) == '.json') {
+      return through();
+    }
+
     var data = "";
 
     var write = function (buf) {


### PR DESCRIPTION
It's quite common to do this:

```
var data = require("./data.json");
```

This doesn't play well with 6to5. This patch adds a filter that ignores JSON files.
