### PR TITLE
Transforms should not be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "bugs": {
     "url": "https://github.com/sebmck/6to5-browserify/issues"
   },
-  "preferGlobal": true,
   "dependencies": {
     "6to5": "*",
     "through": "2.3.4",


### PR DESCRIPTION
Browserify transforms are expected to be somewhere they can be `require`d.
