### PR TITLE
Add error handling via events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@
 ### Node
 
 ```javascript
+var fs = require("fs");
+var browserify = require("browserify");
 var to5Browserify = require("6to5-browserify");
-browserify()
+browserify({ debug: true })
   .transform(to5Browserify)
-  .require("script.js", { entry: true })
-  .bundle({ debug: true })
+  .require("./script.js", { entry: true })
+  .bundle()
+  .on('error', function(err) {console.log('Error : ' + err.message);})
   .pipe(fs.createWriteStream("bundle.js"));
 ```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var browserify = module.exports = function (filename) {
 
 browserify.configure = function (opts) {
   opts = opts || {};
+  opts.sourceMap = opts.sourceMap !== false ? 'inline' : false;
 
   return function (filename) {
     if (path.extname(filename) == '.json') {
@@ -25,7 +26,14 @@ browserify.configure = function (opts) {
       var opts2 = _.clone(opts);
       opts2.filename = filename;
 
-      var out = to5.transform(data, opts2).code;
+      try {
+        var out = to5.transform(data, opts2).code;
+      } catch(err) {
+        stream.emit('error', err);
+        stream.queue(null);
+        return;
+      }
+      
       stream.queue(out);
       stream.queue(null);
     };


### PR DESCRIPTION
Hi, I changed a bit the transform to make the error handling a bit easier when using the API.

Secondly, I made source maps generation 'inline' by default to make the transform easier to use. The Browserify "debug" option alone is more obvious to use. You can still force the "sourceMap" option to false (I don't know if it has an effect on compilation speed).

Lastly, I changed the readme to show the changes and adapted it for the recent versions of Browserify.
