### PR TITLE
Call babelify a "transform" instead of a "plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # babelify
 
-[Babel](https://github.com/babel/babel) [browserify](https://github.com/substack/node-browserify) plugin
+[Babel](https://github.com/babel/babel) [browserify](https://github.com/substack/node-browserify) transform
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babelify",
-  "description": "Babel browserify plugin",
+  "description": "Babel browserify transform",
   "version": "5.0.3",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://github.com/babel/babelify",


### PR DESCRIPTION
Browserify plugins are called with the bundle and have important functional differences from transforms. The Github description should also be changed.