### PR TITLE
Adjust filename to relative to project

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,12 @@ var through = require("through");
 var clone   = require("lodash/lang/clone");
 var babel   = require("babel-core");
 var path    = require("path");
+var parent  = require("get-parent-dir")();
 
 var browserify = module.exports = function (filename, opts) {
-  return browserify.configure(opts)(filename);
+  var adjustedFilename = filename.slice(parent.length + 1);
+
+  return browserify.configure(opts)(adjustedFilename);
 };
 
 browserify.configure = function (opts) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "babel-core": "^5.0.0",
-    "through": "2.3.4",
-    "lodash": "^3.0.0"
+    "get-parent-dir": "^1.0.0",
+    "lodash": "^3.0.0",
+    "through": "2.3.4"
   }
 }


### PR DESCRIPTION
As it stands currently, there is no good way to make use of the `ignore` and `only` options present for babel, because the regexes that are constructed are very strict and browserify (and thus babelify) passes the filename with full path.

This updates the filename to be relative to the project root (`lib/app.js` vs. `/Users/someperson/Projects/someproject/lib/app.js`) so that you can include file filtering options in a portable way.