### PR TITLE
Fix for potential duplicate post-build triggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ browserify.configure = function (opts) {
         this.push(babel.transform(data, opts).code);
       } catch(err) {
         this.emit("error", err);
+        return;
       }
       callback();
     };


### PR DESCRIPTION
I'm using watchify with a post-bundle handler. Without this change, my handler is invoked twice after each babelify transform, once with an error (if there was one) and once without. This change just aborts the code before it falls out of the try/catch to prevent the second call.