### PR TITLE
fix "Unknown option 'base._'" (fixes #129)

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ Babelify.configure = function (opts) {
   delete opts.filename;
 
   // browserify specific options
+  delete opts._;
   delete opts._flags;
   delete opts.basedir;
   delete opts.global;

--- a/test/browserify-cli.js
+++ b/test/browserify-cli.js
@@ -1,0 +1,35 @@
+var path = require('path');
+var spawn = require('child_process').spawn;
+var test = require('tap').test;
+var vm = require('vm');
+
+test('browserify-cli', function (t) {
+  t.plan(3);
+
+  var entry = path.join(__dirname, '/bundle/index.js');
+  var babelify = path.join(__dirname, '../');
+
+  var cmd = require.resolve('browserify/bin/cmd.js');
+  var args = [
+    '-r', entry + ':bundle',
+    '-t', '[', babelify, '--presets', 'es2015', ']'
+  ];
+
+  var out = '';
+  var err = '';
+
+  var ps = spawn(cmd, args);
+  ps.stdout.on('data', function(buf) { out += buf; });
+  ps.stderr.on('data', function(buf) { err += buf; });
+
+  ps.on('error', function(err) { throw err; });
+  ps.on('exit', function(code) {
+    t.notOk(err);
+    t.equal(code, 0);
+
+    var c = {};
+    vm.runInNewContext(out, c);
+
+    t.equal(c.require('bundle').a, 'a is for apple');
+  });
+});


### PR DESCRIPTION
When using babelify via the browserify cli, browserify adds an `_` prop to the options, with the browserify options. Babel 6.0 is now really strict about the options you pass in.