### PR TITLE
Updates babel-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/babel/babelify/issues"
   },
   "dependencies": {
-    "babel-core": "^6.0.14",
+    "babel-core": "^6.2.1",
     "object-assign": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Previously I was experiencing a bug with the es2015-destructuring
plugin. This was caused by the non-definition of `t.numericLiteral`
as the type was still called `numberLiteral`. This bump fixes that
problem.