### PR TITLE
babel-preset-stage-0 is needed in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --save-dev babelify
 
 ```sh
 $ browserify script.js -o bundle.js \
-  -t [ babelify --presets [ es2015 react stage-0 ] ]
+  -t [ babelify --presets [ es2015 react ] ]
 ```
 
 ### Node
@@ -25,7 +25,7 @@ $ browserify script.js -o bundle.js \
 var fs = require("fs");
 var browserify = require("browserify");
 browserify("./script.js")
-  .transform("babelify", {presets: ["es2015", "react", "stage-0"]})
+  .transform("babelify", {presets: ["es2015", "react"]})
   .bundle()
   .pipe(fs.createWriteStream("bundle.js"));
 ```
@@ -33,8 +33,17 @@ browserify("./script.js")
 **NOTE:** [Presets and plugins](http://babeljs.io/docs/plugins/) need to be installed as separate modules. For the above examples to work, you'd need to also install [`babel-preset-es2015`](https://www.npmjs.com/package/babel-preset-es2015) and [`babel-preset-react`](https://www.npmjs.com/package/babel-preset-react):
 
 ```sh
-$ npm install --save-dev babel-preset-es2015 babel-preset-react babel-preset-stage-0
+$ npm install --save-dev babel-preset-es2015 babel-preset-react
 ```
+
+**NOTE:** Some UI libraries such as material-ui is using experimental features, such as:
+
+    class ExampleComponent {
+      handleToggle = () => this.setState({open: !this.state.open});
+      // ...
+    }
+
+In such case you'd need to also install [`babel-preset-stage-0`](https://www.npmjs.com/package/babel-preset-stage-0) to make it work.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ browserify("./script.js")
 $ npm install --save-dev babel-preset-es2015 babel-preset-react
 ```
 
-**NOTE:** Some UI libraries such as material-ui is using experimental features, such as:
+**NOTE:** Some UI libraries such as material-ui (v0.13.4) is using experimental features, such as:
 
     class ExampleComponent {
       handleToggle = () => this.setState({open: !this.state.open});

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --save-dev babelify
 
 ```sh
 $ browserify script.js -o bundle.js \
-  -t [ babelify --presets [ es2015 react ] ]
+  -t [ babelify --presets [ es2015 react stage-0 ] ]
 ```
 
 ### Node
@@ -25,7 +25,7 @@ $ browserify script.js -o bundle.js \
 var fs = require("fs");
 var browserify = require("browserify");
 browserify("./script.js")
-  .transform("babelify", {presets: ["es2015", "react"]})
+  .transform("babelify", {presets: ["es2015", "react", "stage-0"]})
   .bundle()
   .pipe(fs.createWriteStream("bundle.js"));
 ```
@@ -33,7 +33,7 @@ browserify("./script.js")
 **NOTE:** [Presets and plugins](http://babeljs.io/docs/plugins/) need to be installed as separate modules. For the above examples to work, you'd need to also install [`babel-preset-es2015`](https://www.npmjs.com/package/babel-preset-es2015) and [`babel-preset-react`](https://www.npmjs.com/package/babel-preset-react):
 
 ```sh
-$ npm install --save-dev babel-preset-es2015 babel-preset-react
+$ npm install --save-dev babel-preset-es2015 babel-preset-react babel-preset-stage-0
 ```
 
 ### Options


### PR DESCRIPTION
CLI example doesn't work for ES6 arrow function syntax, eg:
`handleToggle = () => this.setState({open: !this.state.open});`

babel-preset-stage-0 seem to be needed to make this transpilation work.

My package.json:
    "babel-preset-es2015": "^6.3.13",
    "babel-preset-react": "^6.3.13",
    "babel-preset-stage-0": "^6.3.13",
    "babelify": "^7.2.0",
    "browserify": "^12.0.1",
    "browserify-incremental": "^3.0.1",

http://stackoverflow.com/questions/33634111/babelify-6-with-browserify-and-the-es2015-preset-is-not-working