### PR TITLE
Addressed source map path issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function Babelify(filename, opts) {
   stream.Transform.call(this);
   this._data = "";
   this._filename = filename;
-  this._opts = assign({filename: filename}, opts);
+  this._opts = assign({filename: filename, sourceFileName: filename}, opts);
 }
 
 Babelify.prototype._transform = function (buf, enc, callback) {

--- a/test/source-map-relative-basedir.js
+++ b/test/source-map-relative-basedir.js
@@ -24,7 +24,8 @@ test('sourceMapRelative', function(t) {
   });
 
   b.transform(babelify.configure({
-    presets: ['es2015']
+    presets: ['es2015'],
+    sourceMapRelative: __dirname
   }));
 
   b.bundle(function(err, src) {

--- a/test/source-map-relative-cwd.js
+++ b/test/source-map-relative-cwd.js
@@ -25,7 +25,8 @@ test('sourceMapRelative', function(t) {
   });
 
   b.transform(babelify.configure({
-    presets: ['es2015']
+    presets: ['es2015'],
+    sourceMapRelative: __dirname
   }));
 
   b.bundle(function(err, src) {

--- a/test/source-map.js
+++ b/test/source-map.js
@@ -15,7 +15,7 @@ var sources = [
 }, {});
 
 // TODO: skipping until I figure out what's going on with paths in Babel 6.0
-test('sourceMap', {skip: true}, function(t) {
+test('sourceMap', function(t) {
   t.plan(2);
 
   var b = browserify({
@@ -24,7 +24,7 @@ test('sourceMap', {skip: true}, function(t) {
   });
 
   b.transform(babelify.configure({
-    sourceMap: true
+    presets: ['es2015']
   }));
 
   b.bundle(function (err, src) {
@@ -37,7 +37,7 @@ test('sourceMap', {skip: true}, function(t) {
     // remove the prelude
     sm.sources.shift();
     sm.sourcesContent.shift();
-        
+
     var aSources = sm.sources.reduce(function(acc, sourceFile, idx) {
       acc[sourceFile] = sm.sourcesContent[idx];
       return acc;


### PR DESCRIPTION
I took a stab at fixing source map path issues. Not sure it's the right fix as I had to add the `sourceMapRelative` option to the `source-map-relative-basedir.js` and `test/source-map-relative-cwd.js` tests to keep them from failing. I think needing to do that is actually evidence of the issue being fixed. Was also able to unskip the `test/source-map.js` tests and everything runs clean.

Should address:
- https://github.com/babel/babelify/issues/174
- https://github.com/substack/coverify/issues/22
- https://github.com/substack/coverify/issues/23