### PR TITLE
Adding sourceRoot option for workspace support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var assign = require("object-assign");
 var stream = require("stream");
 var babel  = require("babel-core");
 var util   = require("util");
+var path   = require("path");
 
 module.exports = Babelify;
 util.inherits(Babelify, stream.Transform);
@@ -68,9 +69,25 @@ Babelify.configure = function (opts) {
     }
 
     var _opts = sourceMapsAbsolute
-      ? assign({sourceFileName: filename}, opts)
+      ? assign({
+        sourceFileName: opts.sourceRoot ? path.relative(
+          opts.sourceRoot,
+          filename
+        )
+        : filename
+      }, opts)
       : opts;
+
+    delete _opts.sourceRoot
 
     return new Babelify(filename, _opts);
   };
 };
+
+
+opts.sourceFileName === undefined
+  ? path.relative(
+      opts.sourceRoot,
+      opts.filename
+    )
+  }

--- a/index.js
+++ b/index.js
@@ -70,11 +70,12 @@ Babelify.configure = function (opts) {
 
     var _opts = sourceMapsAbsolute
       ? assign({
-        sourceFileName: opts.sourceRoot ? path.relative(
-          opts.sourceRoot,
-          filename
-        )
-        : filename
+        sourceFileName: opts.sourceRoot
+          ? path.relative(
+            opts.sourceRoot,
+            filename
+          )
+          : filename
       }, opts)
       : opts;
 
@@ -83,11 +84,3 @@ Babelify.configure = function (opts) {
     return new Babelify(filename, _opts);
   };
 };
-
-
-opts.sourceFileName === undefined
-  ? path.relative(
-      opts.sourceRoot,
-      opts.filename
-    )
-  }


### PR DESCRIPTION
Hi,

First of all, thank you for making babelify, I have used is since the very beginning and it has been great in getting projects off the ground quickly!

I fixed the chrome devtools "workspaces" support by adding a `sourceRoot` option which will be cut off off the absolute path (from the sourcemap filenames) when specified.

Hope you like it!

Let me know if anything needs to change, I can also squash the commits if you prefer that, or can you roll with it the way it this?