### PR TITLE
Feature - scope babel 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,14 @@ browserify({debug: true}).transform("babelify", {sourceMaps: false});
 ```sh
 $ browserify -d -t [ babelify --no-sourceMaps ]
 ```
+
+### Can I use private/different babel package (like scoped babel 7)?
+
+Yes, just pass it along as `babel` option, you still need to install `babel-core <= 6` as babelify uses support functions that were removed on babel 7.
+
+```js
+browserify().transform("babelify", {
+  presets: ["@babel/preset-env"],
+  babel: require("@babel/core")
+});
+```

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ Babelify.configure = function (opts) {
 
   return function (filename) {
     var extname = path.extname(filename)
-    if (extensions.indexOf(ext) === -1) {
+    if (extensions.indexOf(extname) === -1) {
       return stream.PassThrough();
     }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ function Babelify(filename, opts) {
   stream.Transform.call(this);
   this._data = "";
   this._filename = filename;
+  this._babel = opts.babel || babel
+  delete opts.babel
   this._opts = Object.assign({filename: filename}, opts);
 }
 
@@ -23,7 +25,7 @@ Babelify.prototype._transform = function (buf, enc, callback) {
 
 Babelify.prototype._flush = function (callback) {
   try {
-    var result = babel.transform(this._data, this._opts);
+    var result = this._babel.transform(this._data, this._opts);
     this.emit("babelify", result, this._filename);
     var code = result.code;
     this.push(code);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function Babelify(filename, opts) {
   stream.Transform.call(this);
   this._data = "";
   this._filename = filename;
-  this._babel = opts.babel || babel
+  this._babel = opts.babel
   delete opts.babel
   this._opts = Object.assign({filename: filename}, opts);
 }
@@ -25,7 +25,9 @@ Babelify.prototype._transform = function (buf, enc, callback) {
 
 Babelify.prototype._flush = function (callback) {
   try {
-    var result = this._babel.transform(this._data, this._opts);
+    var result = this._babel
+      ? this._babel.transform(this._data, this._opts)
+      : babel.transform(this._data, this._opts);
     this.emit("babelify", result, this._filename);
     var code = result.code;
     this.push(code);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ Babelify.configure = function (opts) {
 
   return function (filename) {
     var extname = path.extname(filename)
-    if (extensions.indexOf(function (ext) {return ext === extname}) > -1) {
+    if (extensions.indexOf(ext) === -1) {
       return stream.PassThrough();
     }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = Babelify;
 util.inherits(Babelify, stream.Transform);
 
 function Babelify(filename, opts) {
+  opts = Object.assign({}, opts)
   if (!(this instanceof Babelify)) {
     return Babelify.configure(opts)(filename);
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/babel/babelify/issues"
   },
   "peerDependencies": {
-    "babel-core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
+    "babel-core": "6 || 7 || 7.x || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.32",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "babel-core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.32",
+    "@babel/preset-env": "^7.0.0-beta.32",
     "babel-core": "^6.0.14",
     "babel-plugin-transform-es3-property-literals": "^6.0.14",
     "babel-plugin-transform-node-env-inline": "^6.0.14",

--- a/test/aaa.js
+++ b/test/aaa.js
@@ -20,3 +20,23 @@ test('aaa', function (t) {
     t.equal(c.require('bundle').a, 'a is for apple');
   });
 });
+
+test('aaa - with optional babel instance', function (t) {
+  t.plan(2);
+
+  var b = browserify();
+
+  b.require(path.join(__dirname, 'bundle/index.js'), {expose: 'bundle'});
+  b.transform([babelify, {
+    babel: require('@babel/core'),
+    presets: ['@babel/env']
+  }]);
+
+  b.bundle(function (err, src) {
+    t.error(err);
+    var c = {};
+    vm.runInNewContext(src, c);
+
+    t.equal(c.require('bundle').a, 'a is for apple');
+  });
+});


### PR DESCRIPTION
I've expended the options to support `babel` option, this options apply only to the `transform` function as the other two uses were [removed](https://github.com/babel/babelify/issues/231) for babel 7, ~~this is not the best approach as we have two separate babel packages running in the package - `babel-core` for configuration setup and the optional babel for transform, but I think that the solution would come from a proper babel 7 integration.~~

For the time being, it is a pretty simple solution for early babel 7 adaptors.

Added:
- Test (basic - option passing and compile)
- `devDependancies` - for testing (`@babel/core`, `@babel/preset-env`)
- Documentation (FAQ section)

**Update:** I've noticed this PR - https://github.com/babel/babelify/pull/244, and removed the `babel-core` dependancies.