### PR TITLE
Upgrade to Babel 7 and @babel scoped packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ As of [Babel 6.0.0](http://babeljs.io/blog/2015/10/29/6.0.0/) there are **no plu
 ## Installation
 
 ```sh
+# Babel 7
+$ npm install --save-dev babelify@next @babel/core
+
+# Babel 6
 $ npm install --save-dev babelify babel-core
 ```
 
@@ -15,7 +19,7 @@ $ npm install --save-dev babelify babel-core
 ### CLI
 
 ```sh
-  $ browserify script.js -o bundle.js -t [ babelify --presets [ env react ] ]
+  $ browserify script.js -o bundle.js -t [ babelify --presets [ "@babel/preset-env", "@babel/preset-react" ] ]
 ```
 
 ### Node
@@ -24,15 +28,15 @@ $ npm install --save-dev babelify babel-core
 var fs = require("fs");
 var browserify = require("browserify");
 browserify("./script.js")
-  .transform("babelify", {presets: ["env", "react"]})
+  .transform("babelify", {presets: ["@babel/preset-env", "@babel/preset-react"]})
   .bundle()
   .pipe(fs.createWriteStream("bundle.js"));
 ```
 
-**NOTE:** [Presets and plugins](http://babeljs.io/docs/plugins/) need to be installed as separate modules. For the above examples to work, you'd need to also install [`babel-preset-env`](https://www.npmjs.com/package/babel-preset-env) and [`babel-preset-react`](https://www.npmjs.com/package/babel-preset-react):
+**NOTE:** [Presets and plugins](http://babeljs.io/docs/plugins/) need to be installed as separate modules. For the above examples to work, you'd need to also install [`@babel/preset-env`](https://www.npmjs.com/package/@babel/preset-env) and [`@babel/preset-react`](https://www.npmjs.com/package/@babel/preset-react):
 
 ```sh
-$ npm install --save-dev babel-preset-env babel-preset-react
+$ npm install --save-dev @babel/preset-env @babel/preset-react
 ```
 
 ### Options
@@ -42,23 +46,23 @@ Selected options are discussed below. See the [babel](http://babeljs.io/) docs f
 Options may be passed in via standard [browserify](https://github.com/substack/node-browserify#btransformtr-opts) ways:
 
 ```sh
-$ browserify -t [ babelify --presets [ env react ] ]
+$ browserify -t [ babelify --presets [ "@babel/preset-env", "@babel/preset-react" ] ]
 ```
 
 ```js
-browserify().transform("babelify", {presets: ["env", "react"]});
+browserify().transform("babelify", {presets: ["@babel/preset-env", "@babel/preset-react"]});
 ```
 
 ```js
 var babelify = require("babelify");
-browserify().transform(babelify, {presets: ["env", "react"]});
+browserify().transform(babelify, {presets: ["@babel/preset-env", "@babel/preset-react"]});
 ```
 
 Or, with the `configure` method:
 
 ```js
 browserify().transform(babelify.configure({
-  presets: ["env", "react"]
+  presets: ["@babel/preset-env", "@babel/preset-react"]
 }));
 ```
 
@@ -178,7 +182,7 @@ specify options then you can use:
 ```json
 {
   "browserify": {
-    "transform": [["babelify", { "presets": ["env"] }]]
+    "transform": [["babelify", { "presets": ["@babel/preset-env"] }]]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -68,8 +68,9 @@ Babelify.configure = function (opts) {
       return stream.PassThrough();
     }
 
-    var _opts = Object.assign({sourceFileName: sourceMapsAbsolute
-      ? filename : path.basename(filename)}, opts);
+    var _opts = sourceMapsAbsolute
+      ? Object.assign({sourceFileName: filename}, opts)
+      : opts;
 
     return new Babelify(filename, _opts);
   };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var stream = require("stream");
-var babel  = require("babel-core");
+var babel  = require("@babel/core");
 var util   = require("util");
+var path   = require("path")
 
 module.exports = Babelify;
 util.inherits(Babelify, stream.Transform);
@@ -22,21 +23,21 @@ Babelify.prototype._transform = function (buf, enc, callback) {
 };
 
 Babelify.prototype._flush = function (callback) {
-  try {
-    var result = babel.transform(this._data, this._opts);
-    this.emit("babelify", result, this._filename);
-    var code = result.code;
-    this.push(code);
-  } catch(err) {
-    this.emit("error", err);
-    return;
-  }
-  callback();
+  babel.transform(this._data, this._opts, (err, result) => {
+    if (err) {
+      this.emit("error", err);
+    } else {
+      this.emit("babelify", result, this._filename);
+      var code = result.code;
+      this.push(code);
+    }
+    callback();
+  });
 };
 
 Babelify.configure = function (opts) {
   opts = Object.assign({}, opts);
-  var extensions = opts.extensions ? babel.util.arrayify(opts.extensions) : null;
+  var extensions = opts.extensions || babel.DEFAULT_EXTENSIONS;
   var sourceMapsAbsolute = opts.sourceMapsAbsolute;
   if (opts.sourceMaps !== false) opts.sourceMaps = "inline";
 
@@ -62,13 +63,13 @@ Babelify.configure = function (opts) {
   if (opts.presets && opts.presets._) opts.presets = opts.presets._;
 
   return function (filename) {
-    if (!babel.util.canCompile(filename, extensions)) {
+    var extname = path.extname(filename);
+    if (extensions.indexOf(extname) === -1) {
       return stream.PassThrough();
     }
 
-    var _opts = sourceMapsAbsolute
-      ? Object.assign({sourceFileName: filename}, opts)
-      : opts;
+    var _opts = Object.assign({sourceFileName: sourceMapsAbsolute
+      ? filename : path.basename(filename)}, opts);
 
     return new Babelify(filename, _opts);
   };

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ Babelify.prototype._flush = function (callback) {
       this.emit("babelify", result, this._filename);
       var code = result.code;
       this.push(code);
+      callback();
     }
-    callback();
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,852 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.35.tgz",
+      "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.35.tgz",
+      "integrity": "sha512-+frqefsq9klDZfK2nLjpqeodicqdJX43xUlz/7acxEd4jEbAQbeKrsgrSo/bwXI4nQ/9f9kXKaZchwdIo8LVtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/generator": "7.0.0-beta.35",
+        "@babel/helpers": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "convert-source-map": "1.5.0",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11",
+        "resolve": "1.4.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.35",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.35.tgz",
+          "integrity": "sha512-Y2o5scalPPlI6eOYMat6iqoM8akjqkAv9cXUN/7YNe3FANAsAGcF5L2u6XiUtBECvhyf7LeZYyzNYnjk43Vffg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-5QO6oYlc5xpbZEBFcxdUfzNvtjTwKfttfqkkZZ8FCs7CQwmtqzZMzFvYc+pa8QmMxUF5D8c1+XI/mOy3lYjK7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.35.tgz",
+      "integrity": "sha512-bc2idaE5XgHlyZX7TT+9ij2hhUFa21KVffQY6FTwDRT8BgqgFhIzLMFLRfk7Bd9jj+YwuydHCbdp5jXbeGFfRg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.35.tgz",
+      "integrity": "sha512-lOj12qKqI4hY0KcgyRyaCMp+OEIwuBC90+jrRgHsMmNED//SdcI3TBIDAjBt9fAp3AejS+5eHs374uQQMoPRLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.35.tgz",
+      "integrity": "sha512-wqXGs7vp4EgNAFywcFBZbVTH7OPGYGXcCY29xzGuSNTcH05bE7ZKGBTHLhyITMagwDX0DjY6IDU5qov4bZQI9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35",
+        "esutils": "2.0.2"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.35.tgz",
+      "integrity": "sha512-/pPdGpmi6t8Vj5dAYfAtQ6RRi140VdHh5wAB47ZgqfTfu/atIPOOKoln2PxvNwTGDkKVykmHdyqqOT7YEan76w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.35.tgz",
+      "integrity": "sha512-bS+6/gvj/iq4TtGZuL2//X7RunihWjS+Hp2o/3cPopvU3CK9IPFPpPZc7NiqjPcvlUc47lzHRO+uk77GBONojQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.35.tgz",
+      "integrity": "sha512-GNw4audVWvYOM16+s/ROMt2n37XKCqdJYWxY4eDeEWCcWU2GxoY8+8DYl2dcxUkMHlJ7KV9lNmkPdPHSSyni7A==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.35.tgz",
+      "integrity": "sha512-+216NxQ7/Lvj+iehFBKEhYU/BQ1aqHTWz1bxCDiQWms0qi23iqHA4r+WdRKW/o5dAV5mlTUL4nCBFaNx8LNnRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.35.tgz",
+      "integrity": "sha512-8co9nT1MgbNoGl6too2/jwldu5F7O1rMi+/QsM9bmFuCu76rU5okFWi4cb4Uv0WXZ4BWk6x+Lpdzzu7EgvkAwA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.35.tgz",
+      "integrity": "sha512-fbdw4Aa/RGvzTZ8fktOZvaz+6w2mP62jwiwnCdKxSQ/dvu4WLAxMmoG5j0kKpE43IvYm0S5UDMvHrKyGX8xd3A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz",
+      "integrity": "sha512-vaC1KyIZSuyWb3Lj277fX0pxivyHwuDU4xZsofqgYAbkDxNieMg2vuhzP5AgMweMY7fCQUMTi+BgPqTLjkxXFg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2d2wk8WAPv98avaLLn8tUSNilgPDF1On+y50WKZV6rr6tKZwtmotrL7iyIUIYRU1FGfJ5lkh6ApOIghX17ZfGA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.35",
+        "@babel/helper-simple-access": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.35.tgz",
+      "integrity": "sha512-hr/P3XTAtN5wppGLP4yrOUbvIyOQPmEG6EVsCSE5z0yUueNQzuCxXp0v7sx7/V+c0eP3XLy/lVsuM96cS3VUKQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-n8nsrxmamIy/HqeS+KXiZaZhaElRMTxKzQl8OAOXqllQQ/T4FQEiGyyqdHsjpbd2JmaLT6875Z8uneK7kk+pdg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Ud5eajQ0HRDLN5wMSrEIa+MBgrlcIjTnX0zKyG5YoGBF9jWXLaapH4XUVsyxiprQyc3Y0rAbhMihz7JxAYplmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35",
+        "@babel/helper-wrap-function": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ez6sOMdXeFzGlg2Qbyi//2nbBrftC7RzMpN671Hd87ITP2af3feEWYEKC5O0EXLCcgaNBzNntkScRGV9ez03wg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.35.tgz",
+      "integrity": "sha512-wMUSdnxUEbcVXMeE2YG9sLvxetXVf5Ye3GSKpu0oVzbRkTcKpcauJW3ukTBquPMuiPAa2sLlvk0ZS6zGe0/PHg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Pp3/4agQAldsoX9WtntyVq9yWOl3xuNxlMnqXCspYaJeBlvs4+oX1D3AvTS0ogG2mBMGwJm6wYbI3s8a8IYF8g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2MplGn7unCRsK3G/serxBbVIhm7ntgf/KmnsIjXbSpK1TKMLVu1WyXIcIHGWGgo5FB5/d2OxiNtygM56v7190Q==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.35.tgz",
+      "integrity": "sha512-p60C6MNtY8ZnO9mGDaDaKi1Sd3HXl41IrYtAt79oWORmI23fwnPNkWSV1pgh1SrySHE4loqZEwwy8Cej8zaT5Q==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2YClvzIll/q8UC5+7uLHUAt836/MAHWyX22HVaNKIdpRTY7bys+YW/K0GJ0GM2AlyYwDIu/MGfNPiyW336j4Pw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.35",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ZIlSeE1YbCqTRjGovxD/+GAzeByqG15f0BQI9oEelvC9SKCCOEslAirqWLhc4MXjwSGW/lE9RlFgdwPNf39fBQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.35.tgz",
+      "integrity": "sha512-9Rj3kLA1hjaIYwEOXBve6OGgbA32HqFZnXlT14KsT2PeZfNevQXQhPRde2XcdUzS71p1be8G5JE0R95nXmTyEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-4SBY3ghnwHZNA8VpvuR7QQPo0cYSQ8vQCvAGzYWBDSpQ0vtuOOgwnxOnGy+mGC3o0t7ZyFcu0IaRWpYHP58FWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35",
+        "regexpu-core": "4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regenerate-unicode-properties": "5.1.3",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.35.tgz",
+      "integrity": "sha512-i6igBBo3ED9CyvtwnBjgYkD6x3qJU5B9h97bU6DVaCGbaJKTFfqv8z+4JAO9JG96cfod5aiYdoDbdawfAoX1LA==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.35.tgz",
+      "integrity": "sha512-6+qsWLOIMenw1/sCrtgS/otR7JMr04tJ/21twYHz2oGxc1QQ6oyuKiS3SWk0n2QCQqucCf3YSIF7lZvUeNiKJA==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Oc97eUcDPxAnye/+qq7wGGabMBLwLrntxYzPt3Zr1YnYecKK+BjyUK4+PTX5tKRC4XlToWFijsHet0mj/ZKKBw==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-iqaA0VdD6ajunwXpI92kSaxgrfP/Dqo/LQ+Q33qhfSKvLH/00WfeCfhoD3M0cLzo0tB6STrh/IUCDJAoiFTW7A==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.35.tgz",
+      "integrity": "sha512-RNr1NuPGLSBL+5vQq7hvDm6FPQyK+E6rKVlEwMFTyHNq584J305hC6ZFDtt9TqVDN00yBfldguSUikHNZSyfnw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-PO5ZsTmBtazAfV+Q9KZJPCunmcJwyKW4YNDQuxnnPpiLx4naY+t2zcelO210RoBxTr9IdrjLOXurT/+20wBJTg==",
+      "dev": true
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-vPlHoCv0DKJuawuk0/1GdqGwKNkVDVsbauVJTrdccSG0Vll867RRvBKWXb6fV++2kvXwVFEzBE5+1FHHUaWmOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.35",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-meMmY4WHWALANTGMbfnTUwzpRRoJO4CQubz9+Xqn9/KB4OF9Rz4J2CvEX/QBKXVxdwzBncJH7lkg9nJWaLTtpw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.35.tgz",
+      "integrity": "sha512-6PytBpASHBhPi9pSyOnCip6ZXsOu0yd5ufjs8A06coeVlp6R57IMGOBD8Klk29FUS+FJo367G2s8PxUKDuFQgw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.35.tgz",
+      "integrity": "sha512-D71nw+Brh7IWSHiW4/JDux5EhT4gyMYG1WJVjaXl6D6DQhOFlZf5otUVrVX6IxEQaco3B2dlEBDEt/UXvf9E2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35",
+        "@babel/helper-define-map": "7.0.0-beta.35",
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.35",
+        "@babel/helper-replace-supers": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.35.tgz",
+      "integrity": "sha512-m94sLp/9ktRWRRoMkFkCho2nfURK17JLnJEAIvdn1zPfSGmguq3vk4tfFNQKVZ9lE8W1LlqDdE/2bXVdh7UbzQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.35.tgz",
+      "integrity": "sha512-TL59Z2iI5ohs0jMTq+EGdAB9QWr3SU1XzGisG7ogJe1IX+osupo4Pgd3fxH2hbgtq+QpKM+8DXaKQG/xKDlx6w==",
+      "dev": true
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.35.tgz",
+      "integrity": "sha512-K6/BsBT+oIScy2rvGWP6WWWB1ayU0FNV4rsvHGx2mS4o5G/OmFz52PhViDQxWEoNbU7+2Z263CNgjelzPsX5oA==",
+      "dev": true
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-EC1kqX9stnSzfC8pUxjJZRkeOY4dPtDQtDQBhQVwJZG1NkinJPVlzs0/r0kCQUtBfpmmCvZwKYmsnv02wvqQmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.35.tgz",
+      "integrity": "sha512-18J97mKjqrNNApF+U6Grpenc8yBaFlfZ8nVMFzSPVV/qfP8pKORFsYZKR1dZGsegM9KurPMReuEUvk0PC94Usg==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-flow": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.35.tgz",
+      "integrity": "sha512-iBefZVo6LLNILCaaa5530OANwqQHXjHtu3vdiL9M9A5r0ULj2kAqSNKkMDvQ0Yaxe0M7VzUOHVsWoUzrSDH6lQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.35.tgz",
+      "integrity": "sha512-qHVKPcszzmg6mOJv4Q13zGwmN5hG24yQWVQCtYxpuTIFxu/3EUSI42ocp9hPABw9BhnEI2RiXq82s/2olWglqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.35.tgz",
+      "integrity": "sha512-f98iHJ3fhO5OPP2kijlQ7+kNibbUsSkEVQ28CAA81JtT4fifZUfPgA0S3Piao0fNmxIY6JwSpUH/i+8mRWhfpQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.35.tgz",
+      "integrity": "sha512-0zC8M7Ud8kj8s6/lhyoXM+R3ted522NEe2/EUGjOjhsekyyFs54p34yMPpN/OxDjMHPHpSYmEgrV0HFdtOdx/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.35.tgz",
+      "integrity": "sha512-cg7TRAV1cu92Mk9XYQHsedgZYwaJ+Gc8UakB1d6XiO1+HcP/FsIQgt/1Pa+hAdamwmuEksSKD452JRz5TSGO7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35",
+        "@babel/helper-simple-access": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oHGov6ZhsAQeGW9Gpz7Otrau927948oi1khhKS7GmXcTalDpublxDWcji8FfcJXWt6tyuxVPweuxtTTjeUmtqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.35.tgz",
+      "integrity": "sha512-dWLdxQVQGbgdKWkHkgZuIGVnNiaegqzR3aURgIYIVL3qF2Vo/PnKXNNGnWOSBTSq/lW1oVRi+crj0XmcQR0r5w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.35.tgz",
+      "integrity": "sha512-d/OIA9VIrXHPc5gMqJa1KKIHGlo8qmpIIQJ4qF9TUeTBoRfSyjI6R656d25pjeaswIKndKTtdfngFRhwguXBSA==",
+      "dev": true
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oEPs8cPd5vAYExYWjBECl84ZOjFUj0lLGs0vrUn9jy5nbrhGQi9mjfKs8kV0kmoXsFLXD3LLrsJj4G4JPndvMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-replace-supers": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.35.tgz",
+      "integrity": "sha512-mkDK9XjLcJ66WsfjjAbCzEsJnn7KRKt9osD1MvnVPJ2v2QaRGeh+eHKlENisRj6itk/zhxpcTe8jG/ObnM1PNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.0.0-beta.35",
+        "@babel/helper-get-function-arity": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.0.0-beta.35.tgz",
+      "integrity": "sha512-gcLbsy0k8yhAZk01Dr9G57XSRgkcqQICySMLLbwcnbc1VM+Ya2k00A2NjndZLUYRcWpQhypQ9AesztH0pbncSA==",
+      "dev": true
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ZWvuSs3kJwBZBzDChJmACLJ/CHp4K00g+7UPnA1lN9BEybPna/zGRePYWJBQyu274OTVbnriMCuFMXn7Kj0Nog==",
+      "dev": true
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ncvq+nD3SqqvXzRgb8H8Dp95Ul0UVihg+z1eanM2GvI6bN7B/ZRvb8y+26g3vmBbwqBwBX7OfFF1JwGPRcrymg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "7.0.0-beta.35",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.35.tgz",
+      "integrity": "sha512-fOdI6u+yaKAmepCJJPkQzhKcPApXzWFYqozp5c00juA2E5oQPER+ZEPaZskb5O3OBSprDj8C/0zQ/U/erM1rKA==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.35.tgz",
+      "integrity": "sha512-LpC3bCraUue41rxJcyNQyVb8asDS9T6PWngE5WKXUB6qt166ssnW2i5xFgO1dMDQAfS9fvH7+6ZKIN2oSwAWVw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-P621u2eXvPyzkVZd6mAw7omaAZLkZoLF66CavxEsW4YTbeO9aDBM/GgrvbaNUrffv9DfvFbLZVbvJ6LAXSEVYg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.12.2"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.2.tgz",
+          "integrity": "sha512-mo4Xl+yQEvkGnQ6BU+mO4Dit6N8ndtwIJ6fq8naCbNiizlh3DUce/vm1W2GuTuMsckc6+w+TexG3nOdf9niNaQ==",
+          "dev": true,
+          "requires": {
+            "private": "0.1.8"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.35.tgz",
+      "integrity": "sha512-wjWlYd3fxEX1ptGYbxSvXAN+vfPEP7dSL+OXlWB0pVUXuZQYJu9aq9BNZl5gC4slMp2nC7HmHG4KzsTZ3sTCjQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-AaAtOXICT58RER/pgbVR8OlpNAp5JZ90hzUUNqpdg53XFom/Mfb/+JYk9amaPmiEUA+eJtr102PqvclrW5ckWw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-EEzzZi61o/4VZzb5nhcNlZ7NPpRLOviUu+SpcTYIQCf1s9QdoyQ8gqb3+3x3vLhwRcKDe8gLee8INXk3Ebg//g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.35.tgz",
+      "integrity": "sha512-sWkmgwFvztzS9c3FVA4sutoy42QzaPvDOirK1LHK7iv7CfS7VTK4yn71McgKmzq0tjxoRo7fSZ0DfmEf2/N22w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.35.tgz",
+      "integrity": "sha512-NzzikFdDh278dKxlwEG51YTtZj/siAebcbLILL00dM/McDrLETnz7WftfDFpVDvbFem9dLf0y59cq9/br6dp+w==",
+      "dev": true
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-XOFj2eDgoRyVYxbkGeM/1MKZIG79vJgg4UOYPCuJfDF/LkASE88mKMdc24VOch5sfyK+rCr7eFwA3e7MtUfkLg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35",
+        "regexpu-core": "4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regenerate-unicode-properties": "5.1.3",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.35.tgz",
+      "integrity": "sha512-yjXgDXg3lhiKoCVx16af7Toir8/+fYeOK14MnMXnpRg0dDNnsQXQS4gOzp0bEVYejuGKa19pm1BKKPUpUvGKFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-check-constants": "7.0.0-beta.35",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.35",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.35",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.35",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.35",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.35",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.35",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.35",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.35",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.35",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.35",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.35",
+        "@babel/plugin-transform-classes": "7.0.0-beta.35",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.35",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.35",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.35",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.35",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.35",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.35",
+        "@babel/plugin-transform-literals": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.35",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.35",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.35",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.35",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.35",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.35",
+        "@babel/plugin-transform-spread": "7.0.0-beta.35",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.35",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.35",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.35",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.35",
+        "browserslist": "2.10.0",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      }
+    },
+    "@babel/preset-flow": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0-beta.35.tgz",
+      "integrity": "sha512-SMyE22uN4aP1uHaLVhov9AWQ/bRdj1fqGqIlQWpGLJnb9O8m0QN40KAs2pL9N+orIQNTzzRUjqqH1y8csZRWdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.35.tgz",
+      "integrity": "sha512-jiy65aPPkzmZQ6Rrj6vstLeTJVa5EcL9g9GAlZmqsm29TlaHkkGoH8+TZsOT2dfbG4+R6JTC7kEv5u4pfrXWIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.35",
+        "@babel/plugin-transform-react-display-name": "7.0.0-beta.35",
+        "@babel/plugin-transform-react-jsx": "7.0.0-beta.35",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.35",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.35"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.35.tgz",
+      "integrity": "sha512-NLd3Dfs8hmkxPvaD8ohNtEp9WXp48lxpW//6fXcT9bJWIO3isrH3OTYL9kjX7xFPPasJ1E9bUNSaPFUUgvPZSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.35",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.35.tgz",
+          "integrity": "sha512-Y2o5scalPPlI6eOYMat6iqoM8akjqkAv9cXUN/7YNe3FANAsAGcF5L2u6XiUtBECvhyf7LeZYyzNYnjk43Vffg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oj2mjz/20iiDt+X0mlzE2IEkzLyM0nmT1zSUy/6i6vyzitVeoyRaHoM7O81gmAHSfBSqyjWRU0OuD9VIUgj8Vg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.35",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.35.tgz",
+          "integrity": "sha512-Y2o5scalPPlI6eOYMat6iqoM8akjqkAv9cXUN/7YNe3FANAsAGcF5L2u6XiUtBECvhyf7LeZYyzNYnjk43Vffg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.35.tgz",
+      "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -41,6 +887,21 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
     "array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
@@ -57,6 +918,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "asn1": {
@@ -128,456 +995,6 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
-    "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      }
-    },
-    "babel-helper-builder-react-jsx": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-syntax-flow": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-      "dev": true
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-es3-property-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
-      "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-flow-strip-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
     "babel-plugin-transform-node-env-inline": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-node-env-inline/-/babel-plugin-transform-node-env-inline-6.8.0.tgz",
@@ -585,145 +1002,6 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-react-display-name": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-react-jsx": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-react-jsx-self": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-react-jsx-source": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "0.10.1"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-6.22.0.tgz",
-      "integrity": "sha1-lf+tqY/R2MrQtnEDFn1ozfN37TA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "leven": "1.0.2"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
-      }
-    },
-    "babel-preset-flow": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
-      }
-    },
-    "babel-preset-react": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -735,54 +1013,6 @@
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -864,6 +1094,17 @@
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -1027,6 +1268,16 @@
         "pako": "0.2.9"
       }
     },
+    "browserslist": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000783",
+        "electron-to-chromium": "1.3.29"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1054,6 +1305,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
       "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz",
+      "integrity": "sha1-m1SZ+xtQPSNF0SqmuGEoUvQnb/0=",
       "dev": true
     },
     "caseless": {
@@ -1100,6 +1357,21 @@
         "request": "2.42.0",
         "urlgrey": "0.4.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -1561,15 +1833,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
     "detective": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
@@ -1628,6 +1891,12 @@
         "jsbn": "0.1.1"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.29",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.29.tgz",
+      "integrity": "sha1-elgja5VGjD52YAkTSFItZddzazY=",
+      "dev": true
+    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -1683,17 +1952,78 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -1789,11 +2119,24 @@
         "path-is-absolute": "1.0.1"
       }
     },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "har-validator": {
       "version": "2.0.6",
@@ -1824,6 +2167,12 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "hash-base": {
       "version": "2.0.2",
@@ -1873,16 +2222,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
       "dev": true
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
     },
     "htmlescape": {
       "version": "1.1.1",
@@ -1976,13 +2315,40 @@
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -1996,6 +2362,27 @@
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
@@ -2020,6 +2407,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
       "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2059,9 +2455,9 @@
       "optional": true
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
     "json-schema": {
@@ -2129,6 +2525,15 @@
         }
       }
     },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
+    },
     "labeled-stream-splicer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
@@ -2152,12 +2557,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-      "dev": true
-    },
-    "leven": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
       "dev": true
     },
     "lexical-scope": {
@@ -2234,6 +2633,27 @@
         }
       }
     },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -2284,21 +2704,6 @@
         "brace-expansion": "1.1.8"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
     "module-deps": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
@@ -2334,11 +2739,14 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
       "dev": true
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "nyc": {
       "version": "6.6.1",
@@ -4386,6 +4794,16 @@
       "dev": true,
       "optional": true
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4411,18 +4829,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
-      "dev": true
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "pako": {
@@ -4451,6 +4857,18 @@
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "path-browserify": {
@@ -4504,6 +4922,12 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
@@ -4566,6 +4990,47 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
@@ -4616,65 +5081,47 @@
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
+    "regenerate-unicode-properties": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
       "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
       "dev": true
     },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "is-equal-shallow": "0.1.3"
       }
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
-      }
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.42.0",
@@ -4733,6 +5180,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
     "sha.js": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
@@ -4771,12 +5224,6 @@
       "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
       "dev": true
     },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
     "sntp": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
@@ -4792,15 +5239,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
     },
     "split": {
       "version": "0.2.10",
@@ -5105,12 +5543,6 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -5157,6 +5589,12 @@
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
+      "dev": true
+    },
     "unicode-length": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
@@ -5166,6 +5604,28 @@
         "punycode": "1.4.1",
         "strip-ansi": "3.0.1"
       }
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.3",
+        "unicode-property-aliases-ecmascript": "1.0.3"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w==",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -851,9 +851,9 @@
       }
     },
     "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
         "jsonparse": "1.3.1",
@@ -865,6 +865,24 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
       "dev": true
+    },
+    "acorn-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
+      "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -934,9 +952,9 @@
       "optional": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -1021,9 +1039,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1114,14 +1132,15 @@
       "dev": true
     },
     "browser-pack": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
-      "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
+      "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
-        "combine-source-map": "0.7.2",
+        "JSONStream": "1.3.2",
+        "combine-source-map": "0.8.0",
         "defined": "1.0.0",
+        "safe-buffer": "5.1.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1149,9 +1168,9 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
+        "JSONStream": "1.3.2",
         "assert": "1.4.1",
-        "browser-pack": "6.0.2",
+        "browser-pack": "6.0.4",
         "browser-resolve": "1.11.2",
         "browserify-zlib": "0.1.4",
         "buffer": "4.9.1",
@@ -1159,7 +1178,7 @@
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
+        "crypto-browserify": "3.12.0",
         "defined": "1.0.0",
         "deps-sort": "2.0.0",
         "domain-browser": "1.1.7",
@@ -1170,7 +1189,7 @@
         "htmlescape": "1.1.1",
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
-        "insert-module-globals": "7.0.1",
+        "insert-module-globals": "7.0.2",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -1185,13 +1204,13 @@
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
+        "stream-http": "2.8.0",
         "string_decoder": "0.10.31",
         "subarg": "1.0.0",
-        "syntax-error": "1.3.0",
+        "syntax-error": "1.4.0",
         "through2": "2.0.3",
         "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
+        "tty-browserify": "0.0.1",
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4",
@@ -1241,7 +1260,7 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1284,7 +1303,7 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
@@ -1380,9 +1399,9 @@
       "dev": true
     },
     "combine-source-map": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-      "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
         "convert-source-map": "1.1.3",
@@ -1692,7 +1711,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "create-hmac": {
@@ -1706,7 +1725,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "cross-spawn": {
@@ -1730,9 +1749,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -1744,7 +1763,8 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "ctype": {
@@ -1817,7 +1837,7 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
+        "JSONStream": "1.3.2",
         "shasum": "1.0.2",
         "subarg": "1.0.0",
         "through2": "2.0.3"
@@ -1834,13 +1854,21 @@
       }
     },
     "detective": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
+        "acorn": "5.5.0",
         "defined": "1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "dev": true
+        }
       }
     },
     "diff": {
@@ -1857,7 +1885,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "domain-browser": {
@@ -2285,12 +2313,12 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.2.tgz",
+      "integrity": "sha512-p3s7g96Nm62MbHRuj9ZXab0DuJNWD7qcmdUXCOQ/ZZn42DtDXfsLill7bq19lDCx3K3StypqUnuE3H2VmIJFUw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
+        "JSONStream": "1.3.2",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
@@ -2298,6 +2326,26 @@
         "process": "0.11.10",
         "through2": "2.0.3",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "combine-source-map": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+          "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+          "dev": true,
+          "requires": {
+            "convert-source-map": "1.1.3",
+            "inline-source-map": "0.6.2",
+            "lodash.memoize": "3.0.4",
+            "source-map": "0.5.7"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+          "dev": true
+        }
       }
     },
     "invariant": {
@@ -2704,18 +2752,24 @@
         "brace-expansion": "1.1.8"
       }
     },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
     "module-deps": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
+        "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
         "defined": "1.0.0",
-        "detective": "4.5.0",
+        "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
         "parents": "1.0.1",
@@ -4852,7 +4906,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
+        "asn1.js": "4.10.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -4905,7 +4959,7 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "pinkie": {
@@ -4963,7 +5017,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -5032,11 +5086,21 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -5187,9 +5251,9 @@
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -5203,7 +5267,7 @@
       "dev": true,
       "requires": {
         "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "shell-quote": {
@@ -5321,9 +5385,9 @@
       }
     },
     "stream-http": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -5371,14 +5435,6 @@
       "dev": true,
       "requires": {
         "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "supports-color": {
@@ -5388,12 +5444,12 @@
       "dev": true
     },
     "syntax-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
-      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn-node": "1.3.0"
       }
     },
     "tap": {
@@ -5559,9 +5615,9 @@
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
     "url": "https://github.com/babel/babelify/issues"
   },
   "peerDependencies": {
-    "babel-core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
+    "@babel/core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
   },
   "devDependencies": {
-    "babel-core": "^6.0.14",
-    "babel-plugin-transform-es3-property-literals": "^6.0.14",
+    "@babel/core": "^7.0.0-beta.35",
+    "@babel/plugin-transform-property-literals": "^7.0.0-beta.35",
+    "@babel/plugin-transform-react-display-name": "^7.0.0-beta.35",
+    "@babel/preset-env": "^7.0.0-beta.35",
+    "@babel/preset-flow": "^7.0.0-beta.35",
+    "@babel/preset-react": "^7.0.0-beta.35",
     "babel-plugin-transform-node-env-inline": "^6.0.14",
-    "babel-plugin-transform-react-display-name": "^6.0.14",
-    "babel-plugin-undeclared-variables-check": "^6.0.14",
-    "babel-preset-es2015": "^6.0.14",
-    "babel-preset-react": "^6.0.14",
     "browserify": "^13.0.0",
     "convert-source-map": "^1.1.0",
     "lodash.zipobject": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/babel/babelify/issues"
   },
   "peerDependencies": {
-    "@babel/core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
+    "@babel/core": "7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.35",

--- a/test/aaa.js
+++ b/test/aaa.js
@@ -10,7 +10,7 @@ test('aaa', function (t) {
   var b = browserify();
 
   b.require(path.join(__dirname, 'bundle/index.js'), {expose: 'bundle'});
-  b.transform([babelify, {presets: ['es2015']}]);
+  b.transform([babelify, {presets: ['@babel/preset-env']}]);
 
   b.bundle(function (err, src) {
     t.error(err);

--- a/test/babel-source-maps.js
+++ b/test/babel-source-maps.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var babel = require('babel-core');
+var babel = require('@babel/core');
 var convert = require('convert-source-map');
 var fs = require('fs');
 var path = require('path');
@@ -11,22 +11,6 @@ var sourceFile = path.join(__dirname, 'bundle/index.js');
 assert(path.isAbsolute(sourceFile));
 
 var sourceSrc = fs.readFileSync(sourceFile, 'utf8');
-
-test('babel source maps (only filename)', function(t) {
-  var result = babel.transform(sourceSrc, {
-    sourceMaps: 'inline',
-    filename: sourceFile,
-  });
-
-  var sm = convert
-    .fromSource(result.code.toString())
-    .toObject();
-
-  // With only "filename", the source path is the base name.
-  t.same(sm.sources, [path.basename(sourceFile)]);
-
-  t.done();
-});
 
 test('babel source maps (filename and sourceFileName)', function(t) {
   var result = babel.transform(sourceSrc, {

--- a/test/browser-pack-source-maps.js
+++ b/test/browser-pack-source-maps.js
@@ -21,7 +21,7 @@ test('browserify source maps (no basedir)', function(t) {
   });
 
   b.transform(babelify, {
-    presets: ['es2015'],
+    presets: ['@babel/preset-env'],
     sourceMaps: false   // no intermediate source maps
   });
 
@@ -71,7 +71,7 @@ test('browserify source maps (with basedir)', function(t) {
   });
 
   b.transform(babelify, {
-    presets: ['es2015'],
+    presets: ['@babel/preset-env'],
     sourceMaps: false   // no intermediate source maps
   });
 

--- a/test/browserify-cli.js
+++ b/test/browserify-cli.js
@@ -11,8 +11,8 @@ test('browserify-cli no subargs', function (t) {
     '-r', path.join(__dirname, '/bundle/index.js') + ':bundle',
     '-t', '[',
       path.join(__dirname, '../'),
-      '--presets', 'es2015',
-      '--plugins', 'transform-es3-property-literals',
+      '--presets', '@babel/preset-env',
+      '--plugins', '@babel/plugin-transform-property-literals',
     ']',
   ];
 
@@ -48,9 +48,9 @@ test('browserify-cli with subargs', function (t) {
     '-r', path.join(__dirname, '/bundle/react-flow.js') + ':reactFlow',
     '-t', '[',
       path.join(__dirname, '../'),
-      '--presets', '[', 'es2015', 'react', ']',
+      '--presets', '[', '@babel/preset-env', '@babel/preset-react', '@babel/preset-flow', ']',
       '--plugins', '[',
-        'transform-react-display-name',
+        '@babel/plugin-transform-react-display-name',
         'transform-node-env-inline',
       ']',
     ']'

--- a/test/browserify-cli.js
+++ b/test/browserify-cli.js
@@ -11,8 +11,8 @@ test('browserify-cli no subargs', function (t) {
     '-r', path.join(__dirname, '/bundle/index.js') + ':bundle',
     '-t', '[',
       path.join(__dirname, '../'),
-      '--presets', '@babel/preset-env',
-      '--plugins', '@babel/plugin-transform-property-literals',
+      '--presets', '[', '@babel/preset-env', ']',
+      '--plugins', '[', '@babel/plugin-transform-property-literals', ']',
     ']',
   ];
 

--- a/test/bundle/c.js
+++ b/test/bundle/c.js
@@ -1,3 +1,3 @@
 module.exports = function() {
-  variableThatDoesNotExist;
+  return 'c';
 };

--- a/test/bundle/error.js
+++ b/test/bundle/error.js
@@ -1,0 +1,5 @@
+class A {
+  constructor () {
+    super();
+  }
+}

--- a/test/error.js
+++ b/test/error.js
@@ -1,4 +1,4 @@
-/* var browserify = require('browserify');
+var browserify = require('browserify');
 var path = require('path');
 var test = require('tap').test;
 var babelify = require('../');
@@ -6,15 +6,12 @@ var babelify = require('../');
 test('emits error', function(t) {
   t.plan(2);
 
-  var b = browserify(path.join(__dirname, 'bundle/index.js'));
+  var b = browserify(path.join(__dirname, 'bundle/error.js'));
 
-  b.transform(babelify.configure({
-    presets: ['es2015'],
-    plugins: ['undeclared-variables-check']
-  }));
+  b.transform(babelify.configure({presets: ['@babel/preset-env']}));
 
   b.bundle(function (err, src) {
     t.notOk(src);
-    t.match(err, /reference to undeclared variable/i);
+    t.match(err, /super() is only allowed in a derived constructor/i);
   });
-}); */
+});

--- a/test/error.js
+++ b/test/error.js
@@ -1,4 +1,4 @@
-var browserify = require('browserify');
+/* var browserify = require('browserify');
 var path = require('path');
 var test = require('tap').test;
 var babelify = require('../');
@@ -17,4 +17,4 @@ test('emits error', function(t) {
     t.notOk(src);
     t.match(err, /reference to undeclared variable/i);
   });
-});
+}); */

--- a/test/event.js
+++ b/test/event.js
@@ -16,13 +16,13 @@ test('event', function (t) {
   var babelified = [];
 
   var b = browserify(path.join(__dirname, 'bundle/index.js'));
-  b.transform([babelify, {presets: ['es2015']}]);
+  b.transform([babelify, {presets: ['@babel/preset-env']}]);
 
   b.on('transform', function(tr) {
     if (tr instanceof babelify) {
       tr.once('babelify', function(result, filename) {
         babelified.push(filename);
-        t.type(result.metadata.usedHelpers, Array);
+        t.type(result.code, 'string');
       });
     }
   });

--- a/test/options.js
+++ b/test/options.js
@@ -9,8 +9,8 @@ test('passes options via configure', function(t) {
   var b = browserify(path.join(__dirname, 'bundle/index.js'));
 
   b.transform(babelify.configure({
-    presets: ['es2015'],
-    plugins: ['transform-es3-property-literals']
+    presets: ['@babel/preset-env'],
+    plugins: ['@babel/plugin-transform-property-literals']
   }));
 
   b.bundle(function (err, src) {
@@ -26,8 +26,8 @@ test('passes options via browserify', function(t) {
   var b = browserify(path.join(__dirname, 'bundle/index.js'));
 
   b.transform(babelify, {
-    presets: ['es2015'],
-    plugins: ['transform-es3-property-literals']
+    presets: ['@babel/preset-env'],
+    plugins: ['@babel/plugin-transform-property-literals']
   });
 
   b.bundle(function (err, src) {

--- a/test/pkg-app/node_modules/app/package.json
+++ b/test/pkg-app/node_modules/app/package.json
@@ -2,9 +2,9 @@
   "browserify": {
     "transform": [
       ["../../../../", {
-        "presets": ["es2015", "react"],
+        "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-flow"],
         "plugins": [
-          "transform-react-display-name",
+          "@babel/plugin-transform-react-display-name",
           "transform-node-env-inline"
         ]
       }]

--- a/test/source-maps-absolute.js
+++ b/test/source-maps-absolute.js
@@ -25,7 +25,7 @@ test('sourceMapsAbsolute', function(t) {
   });
 
   b.transform(babelify.configure({
-    presets: ['es2015'],
+    presets: ['@babel/preset-env'],
     sourceMapsAbsolute: true
   }));
 

--- a/test/source-maps-relative.js
+++ b/test/source-maps-relative.js
@@ -27,7 +27,7 @@ test('source maps relative (cwd)', function(t) {
   });
 
   b.transform(babelify.configure({
-    presets: ['es2015']
+    presets: ['@babel/preset-env']
   }));
 
   b.bundle(function(err, src) {
@@ -62,7 +62,7 @@ test('source maps relative (basedir)', function(t) {
   });
 
   b.transform(babelify.configure({
-    presets: ['es2015']
+    presets: ['@babel/preset-env']
   }));
 
   b.bundle(function(err, src) {


### PR DESCRIPTION
- Change dependencies/`require` to use @babel scoped packages
- Use asynchronous `babel.transform`
- Replace removed functions/properties: `babel.util.arrayify`, `babel.util.canCompile`, `result.metadata.usedHelpers`
- Even without `sourceFileName`, Babel 7 maps source files to absolute path, if `sourceMapsAbsolute` is false(default), set `sourceFileName` to its base name
- Updated test cases

Fixes #254, fixes #251, fixes #231