### PR TITLE
Check if result is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ Babelify.prototype._flush = function (callback) {
       this.emit("error", err);
     } else {
       this.emit("babelify", result, this._filename);
-      var code = result.code;
+      var code = result !== null ? result.code : this._data;
       this.push(code);
       callback();
     }


### PR DESCRIPTION
This may be the case if files are ignored. I do not know what the other cases are, and if they
should be handled differently, but at least they don't cause error like this. The two failing tests are failing because of unresolved issues concerning source maps, and should be unrelated to this edit.