### PR TITLE
Set `cwd` to the location of the closest package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var findup = require("findup");
 var stream = require("stream");
 var util   = require("util");
 var path   = require("path");
@@ -49,7 +50,7 @@ function buildTransform(opts) {
 }
 
 function normalizeOptions(preconfiguredOpts, transformOpts, filename) {
-  const basedir = normalizeTransformBasedir(transformOpts);
+  const basedir = normalizeTransformBasedir(filename);
   const opts = normalizeTransformOpts(transformOpts);
 
   // Transform options override preconfigured options unless they are undefined.
@@ -95,8 +96,18 @@ function normalizeOptions(preconfiguredOpts, transformOpts, filename) {
   return opts;
 }
 
-function normalizeTransformBasedir(opts) {
-  return path.resolve(opts._flags && opts._flags.basedir || ".");
+var findConfigCache = {};
+
+function normalizeTransformBasedir(filename) {
+  var dirname = path.dirname(filename);
+
+  try {
+    return findConfigCache[dirname] || (
+      findConfigCache[dirname] = findup.sync(dirname, "package.json")
+    );
+  } catch (e) {
+    return dirname;
+  }
 }
 
 function normalizeTransformOpts(opts) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babelify",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1314,6 +1314,11 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -1342,6 +1347,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1664,6 +1674,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
+    },
+    "findup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+      "requires": {
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
+      }
     },
     "foreground-child": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   },
   "scripts": {
     "test": "tap test/*.js"
+  },
+  "dependencies": {
+    "findup": "^0.1.5"
   }
 }

--- a/test/browserify-package.js
+++ b/test/browserify-package.js
@@ -4,9 +4,10 @@ var test = require('tap').test;
 var vm = require('vm');
 
 test('browserify package', function (t) {
-  t.plan(3);
+  t.plan(4);
 
   process.env.NODE_ENV = 'development';
+  process.env.LOCAL_ENV_HIJACK = 'production';
 
   var b = browserify();
   b.require(path.join(__dirname, 'pkg-app/index.js'), {expose: 'pkgApp'});
@@ -20,6 +21,7 @@ test('browserify package', function (t) {
     c.require('pkgApp')({
       createClass: function(obj) {
         t.equal(obj.envLength(), process.env.NODE_ENV.length);
+        t.equal(obj.localEnvHijack(), process.env.LOCAL_ENV_HIJACK.toUpperCase());
         t.equal(obj.displayName, 'TestComponent')
       }
     });

--- a/test/pkg-app/node_modules/app/index.js
+++ b/test/pkg-app/node_modules/app/index.js
@@ -3,6 +3,9 @@ module.exports = (React) => {
     envLength(): number {
       return process.env.NODE_ENV.length;
     },
+    localEnvHijack(): string {
+      return process.env.LOCAL_ENV_HIJACK;
+    },
     render() {
       return <div />;
     }

--- a/test/pkg-app/node_modules/app/node_modules/local-env-transform-hijack/index.js
+++ b/test/pkg-app/node_modules/app/node_modules/local-env-transform-hijack/index.js
@@ -1,0 +1,10 @@
+module.exports = ({ types: t }) => ({
+  name: "local-env-transform-hijack",
+  visitor: {
+    MemberExpression(path) {
+      if (path.matchesPattern("process.env.LOCAL_ENV_HIJACK")) {
+        path.replaceWith(t.valueToNode(process.env.LOCAL_ENV_HIJACK.toUpperCase()));
+      }
+    }
+  }
+});

--- a/test/pkg-app/node_modules/app/package.json
+++ b/test/pkg-app/node_modules/app/package.json
@@ -5,6 +5,7 @@
         "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-flow"],
         "plugins": [
           "@babel/plugin-transform-react-display-name",
+          "module:local-env-transform-hijack",
           "transform-node-env-inline"
         ]
       }]


### PR DESCRIPTION
This ensures that packages within node_modules that use babelify will resolve babel plugins and presets relative to their own `package.json` file, instead of resolving plugins and presets from the project root.

This is more consistent with the expected behaviour of browserify transforms, which should work in a dependency without any configuration required by the end user. Previously, developers would have to install all plugins/presets used by babelify within their dependency tree.

Note that this is a breaking change — will likely require a major version bump.

Thanks! :sparkles: