### PR TITLE
fix browserify cli extensions subarg array

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ function normalizeTransformOpts(opts) {
   if (opts.only && opts.only._) opts.only = opts.only._;
   if (opts.plugins && opts.plugins._) opts.plugins = opts.plugins._;
   if (opts.presets && opts.presets._) opts.presets = opts.presets._;
+  if (opts.extensions && opts.extensions._) opts.extensions = opts.extensions._;
 
   // browserify specific options
   delete opts._flags;


### PR DESCRIPTION
Overriding the default extensions (.js, .es, .es6 and .jsx) using cli option `--extensions [ ]` leads to TypeError, reported [here](https://github.com/babel/babelify/issues/278).

This commit allows devs to use subarg array instead of repeating `--extensions .ext1 --extensions .ext2 ...`