### PR TITLE
fix docs and add test: `ignore` and `only` take arrays as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ $ browserify -t [ babelify --sourceMapsAbsolute ]
 browserify().transform(babelify.configure({
   // Optional ignore regex - if any filenames **do** match this regex then
   // they aren't compiled
-  ignore: /regex/,
+  ignore: [/regex/],
 
   // Optional only regex - if any filenames **don't** match this regex
   // then they aren't compiled
-  only: /my_es6_folder/
+  only: [/my_es6_folder/]
 }))
 ```
 
@@ -192,7 +192,7 @@ Another solution (proceed with caution!) is to run babelify as a [global](https:
 ```js
 browserify().transform("babelify", {
   global: true,
-  ignore: /\/node_modules\/(?!app\/)/
+  ignore: [/\/node_modules\/(?!app\/)/]
 });
 ```
 

--- a/test/options.js
+++ b/test/options.js
@@ -10,7 +10,9 @@ test('passes options via configure', function(t) {
 
   b.transform(babelify.configure({
     presets: ['@babel/preset-env'],
-    plugins: ['@babel/plugin-transform-property-literals']
+    plugins: ['@babel/plugin-transform-property-literals'],
+    ignore: [/fakeregex/],
+    only: [/index.js$/, /a.js$/, /b.js$/, /c.js$/]
   }));
 
   b.bundle(function (err, src) {
@@ -27,7 +29,9 @@ test('passes options via browserify', function(t) {
 
   b.transform(babelify, {
     presets: ['@babel/preset-env'],
-    plugins: ['@babel/plugin-transform-property-literals']
+    plugins: ['@babel/plugin-transform-property-literals'],
+    ignore: [/fakeregex/],
+    only: [/index.js$/, /a.js$/, /b.js$/, /c.js$/]
   });
 
   b.bundle(function (err, src) {


### PR DESCRIPTION
- just passing a single regex causes errors:
  - Error: .ignore must be an array, or undefined
  - Error: .only must be an array, or undefined