### PR TITLE
now extensions could be used in an array when using browserify cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ function normalizeTransformOpts(opts) {
   if (opts.only && opts.only._) opts.only = opts.only._;
   if (opts.plugins && opts.plugins._) opts.plugins = opts.plugins._;
   if (opts.presets && opts.presets._) opts.presets = opts.presets._;
+  if (opts.extensions && opts.extensions._) opts.extensions = opts.extensions._;
 
   // browserify specific options
   delete opts._flags;


### PR DESCRIPTION
Got a

`if (extensions.indexOf(extname) === -1) { TypeError: extensions.indexOf is not a function`

at **babelify/index.js:75** when using Browserify CLI like this:

<pre>[ babelify --presets [ @babel/preset-env @babel/preset-react ] <b>--extensions [ .tsx .js .ts ]</b> --plugins [ @babel/plugin-proposal-class-properties @babel/transform-runtime] ]</pre>

My PR should fix it.